### PR TITLE
Fix file loading in fbc_curation

### DIFF
--- a/src/fbc_curation/curator/fbc_curation.m
+++ b/src/fbc_curation/curator/fbc_curation.m
@@ -26,7 +26,15 @@ else
 end
 
 t = tic; fprintf('Loading model from %s... ', fileName);
-model = readCbModel(fileName);
+
+%load the file
+if (extractAfter(fileName,".") == 'xml')
+        model = readCbModel(fileName);
+elseif (extractAfter(fileName,".") == 'mat')
+        updated_filename = replace(fileName, "'", '');
+        load(updated_filename);
+end
+
 toc(t);
 nRxns = numel(model.rxns);
 


### PR DESCRIPTION
Fix an issue with loading .mat model files, the code will now take both .mat and .xml file as input.