### PR TITLE
Changed code to avoid TranslateSBML for XML files

### DIFF
--- a/src/fbc_curation/curator/run_FROG.m
+++ b/src/fbc_curation/curator/run_FROG.m
@@ -46,11 +46,14 @@ exact_file_name = split(fileName, '\');
 if (extractAfter(fileName,".") == 'xml')
         model = readCbModel(fileName);
         modelSBML = TranslateSBML(fileName,0,0,[1 1]);
-        sbmlReactions = modelSBML.reaction;
-        sbmlReactionids = columnVector({sbmlReactions.id});
-        sbmlGeneids = columnVector({modelSBML.fbc_geneProduct.fbc_id});
+        %sbmlReactions = modelSBML.reaction;
+        %sbmlReactionids = columnVector({sbmlReactions.id});
+        sbmlReactionids = model.rxns;
+        %sbmlGeneids = columnVector({modelSBML.fbc_geneProduct.fbc_id});
+        sbmlGeneids = model.genes;
         if ~exist('objective_name','var')
-            objective_name = modelSBML.fbc_activeObjective;
+            %objective_name = modelSBML.fbc_activeObjective;
+            objective_name = 'obj';
         end
 elseif (extractAfter(fileName,".") == 'mat')
         updated_filename = replace(fileName, "'", '');


### PR DESCRIPTION
TranslateSBML does not read all XML files and instead creates empty model structures without reactions and genes. 